### PR TITLE
docs(README.md): removing unexpected character when copying the install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Go library to connect with [Stone Open Banking API](https://docs.openbank.ston
 ## How to install
 
 ```sh
-  $ go get github.com/stone-co/go-stone-openbank
+go get github.com/stone-co/go-stone-openbank
 ```
 
 ## Example Usage


### PR DESCRIPTION
Following the readme of the project, copy and paste directly the command to install, failure, because contains unexpected characters that invalid the command.

Someone distracted have chance of don't to perceive.

![sample](https://user-images.githubusercontent.com/17557482/139588905-29919531-e5bc-46fa-86fc-5a7f0fe33135.gif)
