### PR TITLE
Feature/list keys pix

### DIFF
--- a/account.go
+++ b/account.go
@@ -20,7 +20,7 @@ func (s *AccountService) Get(id string) (*types.Account, *Response, error) {
 
 	path := fmt.Sprintf("/api/v1/accounts/%s", id)
 
-	req, err := s.client.NewAPIRequest(http.MethodGet, path, nil)
+	req, err := s.client.NewAPIRequest(http.MethodGet, path, emptyIdempotencyKey, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -39,7 +39,7 @@ func (s *AccountService) List() ([]types.Account, *Response, error) {
 
 	path := "/api/v1/accounts?paginate=true"
 
-	req, err := s.client.NewAPIRequest(http.MethodGet, path, nil)
+	req, err := s.client.NewAPIRequest(http.MethodGet, path, emptyIdempotencyKey, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -62,7 +62,7 @@ func (s *AccountService) GetBalance(id string) (*types.Balance, *Response, error
 
 	path := fmt.Sprintf("/api/v1/accounts/%s/balance", id)
 
-	req, err := s.client.NewAPIRequest(http.MethodGet, path, nil)
+	req, err := s.client.NewAPIRequest(http.MethodGet, path, emptyIdempotencyKey, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -81,7 +81,7 @@ func (s *AccountService) GetStatement(id string) ([]types.Statement, *Response, 
 
 	path := fmt.Sprintf("/api/v1/accounts/%s/statement", id)
 
-	req, err := s.client.NewAPIRequest(http.MethodGet, path, nil)
+	req, err := s.client.NewAPIRequest(http.MethodGet, path, emptyIdempotencyKey, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -104,7 +104,7 @@ func (s *AccountService) GetStatementEntry(id string) (*types.Statement, *Respon
 
 	path := fmt.Sprintf("/api/v1/statement/entries/%s", id)
 
-	req, err := s.client.NewAPIRequest(http.MethodGet, path, nil)
+	req, err := s.client.NewAPIRequest(http.MethodGet, path, emptyIdempotencyKey, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -126,7 +126,7 @@ func (s *AccountService) GetFees(accountID string, feeType string) (*types.Fee, 
 
 	path := fmt.Sprintf("/api/v1/accounts/%s/fees/%s", accountID, feeType)
 
-	req, err := s.client.NewAPIRequest(http.MethodGet, path, nil)
+	req, err := s.client.NewAPIRequest(http.MethodGet, path, emptyIdempotencyKey, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -144,7 +144,7 @@ func (s *AccountService) GetFees(accountID string, feeType string) (*types.Fee, 
 func (s *AccountService) ListFees(accountID string) ([]types.Fee, *Response, error) {
 	path := fmt.Sprintf("/api/v1/accounts/%s/fees", accountID)
 
-	req, err := s.client.NewAPIRequest(http.MethodGet, path, nil)
+	req, err := s.client.NewAPIRequest(http.MethodGet, path, emptyIdempotencyKey, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/rsa"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -20,12 +21,14 @@ import (
 )
 
 const (
-	libraryVersion    = "1.0"
-	prodAccountURL    = "https://accounts.openbank.stone.com.br"
-	sandboxAccountURL = "https://sandbox-accounts.openbank.stone.com.br"
-	prodAPIBaseURL    = "https://api.openbank.stone.com.br"
-	sandboxAPIBaseURL = "https://sandbox-api.openbank.stone.com.br"
-	userAgent         = "go-stone-openbank/" + libraryVersion
+	libraryVersion        = "1.0"
+	prodAccountURL        = "https://accounts.openbank.stone.com.br"
+	sandboxAccountURL     = "https://sandbox-accounts.openbank.stone.com.br"
+	prodAPIBaseURL        = "https://api.openbank.stone.com.br"
+	sandboxAPIBaseURL     = "https://sandbox-api.openbank.stone.com.br"
+	userAgent             = "go-stone-openbank/" + libraryVersion
+	idempotencyKeyMaxSize = 72
+	emptyIdempotencyKey   = ""
 )
 
 type Client struct {
@@ -236,7 +239,7 @@ func CheckResponse(r *http.Response) error {
 
 // NewAPIRequest creates an API request. A relative URL PATH can be provided in pathStr, which will be resolved to the
 // ApiBaseURL of the Client.
-func (c *Client) NewAPIRequest(method, pathStr string, body interface{}) (*http.Request, error) {
+func (c *Client) NewAPIRequest(method, pathStr, idempotencyKey string, body interface{}) (*http.Request, error) {
 	u, err := c.ApiBaseURL.Parse(pathStr)
 	if err != nil {
 		return nil, err
@@ -258,6 +261,14 @@ func (c *Client) NewAPIRequest(method, pathStr string, body interface{}) (*http.
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("User-Agent", c.UserAgent)
+
+	if idempotencyKey != "" {
+		if len(idempotencyKey) > idempotencyKeyMaxSize {
+			return nil, errors.New("invalid idempotency key")
+		}
+		req.Header.Add("x-stone-idempotency-key", idempotencyKey)
+	}
+
 	return req, nil
 }
 

--- a/example/main.go
+++ b/example/main.go
@@ -223,14 +223,14 @@ func main() {
 		}
 	}
 
-	//List Keys Pix
+	//List PIX Keys
 	accountID := "968cc34d-d827-448b-ac1b-e6e29836a160"
 	idempotencyKey := uuid.New().String()
-	keysPix, _, err := client.PIXService.ListKeys(accountID, idempotencyKey)
+	pixKeys, _, err := client.PIXService.ListKeys(accountID, idempotencyKey)
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Printf("Keys Pix: %+v\n", keysPix)
+	log.Printf("Keys Pix: %+v\n", pixKeys)
 
 	//Get Outbound Pix
 	PixID := "b5c2354c-91a0-4837-bb15-7f88fcd9d4c5"

--- a/example/main.go
+++ b/example/main.go
@@ -222,6 +222,31 @@ func main() {
 			log.Printf("Payment Invoice[%d]: %+v\n", i, invoice)
 		}
 	}
+
+	//List Keys Pix
+	accountID := "968cc34d-d827-448b-ac1b-e6e29836a160"
+	idempotencyKey := uuid.New().String()
+	keysPix, _, err := client.PIXService.ListKeys(accountID, idempotencyKey)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Keys Pix: %+v\n", keysPix)
+
+	//Get Outbound Pix
+	PixID := "b5c2354c-91a0-4837-bb15-7f88fcd9d4c5"
+	outBoundPix, _, err := client.PIXService.GetOutboundPix(PixID)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Outbound Pix: %+v\n", outBoundPix)
+
+	//Get QRCode Data
+	getQRCodeInput := types.GetQRCodeInput{BRCode: "00020126580014br.gov.bcb.pix0136123e4567-e12b-12d1-a456-4266554400005204000053039865802BR5913Fulano de Tal6008BRASILIA62070503***63041D3D"}
+	qrCode, _, err := client.PIXService.GetQRCodeData(getQRCodeInput)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("QRCode Data: %+v\n", qrCode)
 }
 
 func readFileContent(path string) []byte {

--- a/institution.go
+++ b/institution.go
@@ -24,7 +24,7 @@ func (s InstitutionService) Get(context string) (*types.Institution, *Response, 
 
 	path := fmt.Sprintf("/api/v1/institutions/%s", context)
 
-	req, err := s.client.NewAPIRequest(http.MethodGet, path, nil)
+	req, err := s.client.NewAPIRequest(http.MethodGet, path, emptyIdempotencyKey, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -43,7 +43,7 @@ func (s InstitutionService) List(context InstitutionContext) ([]types.Institutio
 
 	path := fmt.Sprintf("/api/v1/institutions?context=%s", context)
 
-	req, err := s.client.NewAPIRequest(http.MethodGet, path, nil)
+	req, err := s.client.NewAPIRequest(http.MethodGet, path, emptyIdempotencyKey, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/payment_invoice.go
+++ b/payment_invoice.go
@@ -9,8 +9,6 @@ import (
 	"github.com/stone-co/go-stone-openbank/types"
 )
 
-const idempotencyKeyMaxSize = 72
-
 // PaymentInvoiceService handlers communication with Stone Openbank API
 type PaymentInvoiceService struct {
 	client *Client
@@ -23,16 +21,9 @@ func (s *PaymentInvoiceService) PaymentInvoice(input types.PaymentInvoiceInput, 
 		return nil, nil, err
 	}
 
-	req, err := s.client.NewAPIRequest(http.MethodPost, path, input)
+	req, err := s.client.NewAPIRequest(http.MethodPost, path, idempotencyKey, input)
 	if err != nil {
 		return nil, nil, err
-	}
-
-	if idempotencyKey != "" {
-		if len(idempotencyKey) > idempotencyKeyMaxSize {
-			return nil, nil, errors.New("invalid idempotency key")
-		}
-		req.Header.Add("x-stone-idempotency-key", idempotencyKey)
 	}
 
 	var paymentInvoice types.PaymentInvoice
@@ -51,7 +42,7 @@ func (s *PaymentInvoiceService) List(accountID string) ([]types.PaymentInvoice, 
 		return nil, nil, errors.New("account_id can't be empty")
 	}
 
-	req, err := s.client.NewAPIRequest(http.MethodGet, path, nil)
+	req, err := s.client.NewAPIRequest(http.MethodGet, path, emptyIdempotencyKey, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -77,7 +68,7 @@ func (s *PaymentInvoiceService) Get(paymentInvoiceID string) (types.PaymentInvoi
 		return paymentInvoice, nil, errors.New("payment_invoice_id can't be empty")
 	}
 
-	req, err := s.client.NewAPIRequest(http.MethodGet, path, nil)
+	req, err := s.client.NewAPIRequest(http.MethodGet, path, emptyIdempotencyKey, nil)
 	if err != nil {
 		return paymentInvoice, nil, err
 	}
@@ -98,7 +89,7 @@ func (s *PaymentInvoiceService) Cancel(paymentInvoiceID string) (*Response, erro
 
 	path := fmt.Sprintf("/api/v1/barcode_payment_invoices/%s/cancel", paymentInvoiceID)
 
-	req, err := s.client.NewAPIRequest(http.MethodPost, path, nil)
+	req, err := s.client.NewAPIRequest(http.MethodPost, path, emptyIdempotencyKey,nil)
 	if err != nil {
 		return nil, err
 	}

--- a/payment_link.go
+++ b/payment_link.go
@@ -27,7 +27,7 @@ func (s *PaymentLinkService) Get(accountID, orderID string) (types.PaymentLink, 
 
 	path := fmt.Sprintf("/api/v1/payment_links/%s/orders/%s", accountID, orderID)
 
-	req, err := s.client.NewAPIRequest(http.MethodGet, path, nil)
+	req, err := s.client.NewAPIRequest(http.MethodGet, path, emptyIdempotencyKey, nil)
 	if err != nil {
 		return types.PaymentLink{}, nil, err
 	}
@@ -45,7 +45,7 @@ func (s *PaymentLinkService) Get(accountID, orderID string) (types.PaymentLink, 
 func (s *PaymentLinkService) Create(input types.PaymentLinkInput) (types.PaymentLink, *Response, error) {
 	path := "/api/v1/payment_links/orders"
 
-	req, err := s.client.NewAPIRequest(http.MethodPost, path, input)
+	req, err := s.client.NewAPIRequest(http.MethodPost, path, emptyIdempotencyKey, input)
 	if err != nil {
 		return types.PaymentLink{}, nil, err
 	}
@@ -73,7 +73,7 @@ func (s *PaymentLinkService) Cancel(orderID string, input types.PaymentLinkCance
 
 	path := fmt.Sprintf("/api/v1/payment_links/orders/%s/closed", orderID)
 
-	req, err := s.client.NewAPIRequest(http.MethodPatch, path, input)
+	req, err := s.client.NewAPIRequest(http.MethodPatch, path, emptyIdempotencyKey, input)
 	if err != nil {
 		return types.PaymentLink{}, nil, err
 	}

--- a/pix.go
+++ b/pix.go
@@ -48,3 +48,25 @@ func (s *PIXService) GetQRCodeData(input types.GetQRCodeInput) (*types.QRCode, *
 
 	return &qrcode, resp, err
 }
+
+//ListKeys list the keys PIX of an account
+func (s *PIXService) ListKeys(accountID string, idempotencyKey string) ([]types.KeyPIX, *Response, error){
+	path := fmt.Sprintf("/api/v1/pix/%s/entries", accountID)
+
+	req, err := s.client.NewAPIRequest(http.MethodGet, path, idempotencyKey, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var dataResp struct {
+		Cursor types.Cursor `json:"cursor"`
+		Data   []types.KeyPIX  `json:"data"`
+	}
+
+	resp, err := s.client.Do(req, &dataResp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return dataResp.Data, resp, err
+}

--- a/pix.go
+++ b/pix.go
@@ -49,8 +49,8 @@ func (s *PIXService) GetQRCodeData(input types.GetQRCodeInput) (*types.QRCode, *
 	return &qrcode, resp, err
 }
 
-//ListKeys list the keys PIX of an account
-func (s *PIXService) ListKeys(accountID string, idempotencyKey string) ([]types.KeyPIX, *Response, error){
+//ListKeys list the PIX keys of an account
+func (s *PIXService) ListKeys(accountID string, idempotencyKey string) ([]types.PIXKey, *Response, error){
 	path := fmt.Sprintf("/api/v1/pix/%s/entries", accountID)
 
 	req, err := s.client.NewAPIRequest(http.MethodGet, path, idempotencyKey, nil)
@@ -59,8 +59,8 @@ func (s *PIXService) ListKeys(accountID string, idempotencyKey string) ([]types.
 	}
 
 	var dataResp struct {
-		Cursor types.Cursor `json:"cursor"`
-		Data   []types.KeyPIX  `json:"data"`
+		Cursor types.Cursor   `json:"cursor"`
+		Data   []types.PIXKey `json:"data"`
 	}
 
 	resp, err := s.client.Do(req, &dataResp)

--- a/pix.go
+++ b/pix.go
@@ -17,7 +17,7 @@ func (s *PIXService) GetOutboundPix(id string) (*types.PIXOutBoundOutput, *Respo
 
 	path := fmt.Sprintf("/api/v1/pix/outbound_pix_payments/%s", id)
 
-	req, err := s.client.NewAPIRequest(http.MethodGet, path, nil)
+	req, err := s.client.NewAPIRequest(http.MethodGet, path, emptyIdempotencyKey,nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -35,7 +35,7 @@ func (s *PIXService) GetOutboundPix(id string) (*types.PIXOutBoundOutput, *Respo
 func (s *PIXService) GetQRCodeData(input types.GetQRCodeInput) (*types.QRCode, *Response, error) {
 	const path = "/api/v1/pix/outbound_pix_payments/brcodes"
 
-	req, err := s.client.NewAPIRequest(http.MethodGet, path, input)
+	req, err := s.client.NewAPIRequest(http.MethodGet, path, emptyIdempotencyKey, input)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/transfer.go
+++ b/transfer.go
@@ -61,13 +61,9 @@ func (s *TransferService) transfer(input types.TransferInput, idempotencyKey, pa
 		path = fmt.Sprintf("%s/internal_transfers", path)
 	}
 
-	req, err := s.client.NewAPIRequest(http.MethodPost, path, input)
+	req, err := s.client.NewAPIRequest(http.MethodPost, path, idempotencyKey, input)
 	if err != nil {
 		return nil, nil, err
-	}
-
-	if idempotencyKey != "" {
-		req.Header.Add("x-stone-idempotency-key", idempotencyKey)
 	}
 
 	var transfer types.Transfer
@@ -92,7 +88,7 @@ func (s *TransferService) ListExternal(accountID string) ([]types.Transfer, *Res
 }
 
 func (s *TransferService) list(path string) ([]types.Transfer, *Response, error) {
-	req, err := s.client.NewAPIRequest(http.MethodGet, path, nil)
+	req, err := s.client.NewAPIRequest(http.MethodGet, path, emptyIdempotencyKey, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -123,7 +119,7 @@ func (s *TransferService) GetExternal(transferID string) (*types.Transfer, *Resp
 }
 
 func (s *TransferService) get(path string) (*types.Transfer, *Response, error) {
-	req, err := s.client.NewAPIRequest(http.MethodGet, path, nil)
+	req, err := s.client.NewAPIRequest(http.MethodGet, path, emptyIdempotencyKey,nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -150,7 +146,7 @@ func (s *TransferService) CancelExternal(transferID string) (*Response, error) {
 }
 
 func (s *TransferService) cancel(path string) (*Response, error) {
-	req, err := s.client.NewAPIRequest(http.MethodDelete, path, nil)
+	req, err := s.client.NewAPIRequest(http.MethodDelete, path, emptyIdempotencyKey,nil)
 	if err != nil {
 		return nil, err
 	}

--- a/types/pix.go
+++ b/types/pix.go
@@ -84,7 +84,7 @@ type BeneficiaryEntity struct {
 	Document string `json:"document"`
 }
 
-type KeyPIX struct {
+type PIXKey struct {
 	ID string `json:"id"`
 	Key string `json:"key"`
 	KeyType string `json:"key_type"`

--- a/types/pix.go
+++ b/types/pix.go
@@ -88,7 +88,7 @@ type KeyPIX struct {
 	ID string `json:"id"`
 	Key string `json:"key"`
 	KeyType string `json:"key_type"`
-	KeyStatus string `json:"key_status"`
+	Status string `json:"status"`
 	AccountID string `json:"account_id"`
 	ParticipantISPB string `json:"participant_ispb"`
 	BeneficiaryAccount *BeneficiaryAccount `json:"beneficiary_account"`

--- a/types/pix.go
+++ b/types/pix.go
@@ -70,3 +70,27 @@ type QRCodeStatic struct {
 	TxnID  string `json:"transaction_id,omitempty"`
 	Amount int    `json:"amount,omitempty"`
 }
+
+type BeneficiaryAccount struct {
+	BranchCode string `json:"branch_code"`
+	AccountCode string `json:"account_code"`
+	AccountType string `json:"account_type"`
+	CreatedAt string `json:"created_at"`
+}
+
+type BeneficiaryEntity struct {
+	Name string `json:"name"`
+	DocumentType string `json:"document_type"`
+	Document string `json:"document"`
+}
+
+type KeyPIX struct {
+	ID string `json:"id"`
+	Key string `json:"key"`
+	KeyType string `json:"key_type"`
+	KeyStatus string `json:"key_status"`
+	AccountID string `json:"account_id"`
+	ParticipantISPB string `json:"participant_ispb"`
+	BeneficiaryAccount *BeneficiaryAccount `json:"beneficiary_account"`
+	BeneficiaryEntity *BeneficiaryEntity `json:"beneficiary_entity"`
+}


### PR DESCRIPTION
### Description:

The endpoints of PIX key utilize of idempotency key to making idempotent requests.

In the project, other endpoints were utilizing the same behavior, I took this opportunity to refactor and encapsulate this in the creation of a request.

---

### Issue: 
[List keys pix](https://github.com/stone-co/go-stone-openbank/issues/38)

---

### Evidence:

I tested the listing of the pix keys and other endpoints affected with the refactoring of the idempotency key.

![evidence](https://user-images.githubusercontent.com/17557482/140255623-f7344167-907b-4cbb-8103-afb8b0c0360e.png)

### Note:

The name of property referent to PIX key status of it is different, in the docs is key_status, but in response is status.

Beyond other data that are not in the documentation, but I only followed the documentation.

![more-data](https://user-images.githubusercontent.com/17557482/140256217-7fbb9d11-6975-40bf-984d-f642aa8b4321.png)

