### PR TITLE
fix: change jwt payload b64 decoding strategy

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -52,7 +52,7 @@ func getPayload(jwe *jose.JSONWebSignature) ([]byte, error) {
 		return nil, err
 	}
 
-	b, err := base64.RawStdEncoding.DecodeString(p.Payload)
+	b, err := base64.RawURLEncoding.DecodeString(p.Payload)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
in order to comply with JWT specification, we are changing base64 decoding strategy to url encoding without padding. [to learn more](https://datatracker.ietf.org/doc/html/rfc7519#section-3)
